### PR TITLE
Implement auth service and tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -23,7 +23,10 @@
   "devDependencies": {
     "@types/node": "^24.0.3",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "jest": "^29.6.1",
+    "ts-jest": "^29.1.1",
+    "@types/jest": "^29.5.8"
   },
   "dependencies": {
     "firebase-admin": "^13.4.0",

--- a/tests/authService.test.ts
+++ b/tests/authService.test.ts
@@ -1,0 +1,89 @@
+import { AuthService } from '../src/services/authService';
+import * as admin from 'firebase-admin';
+import { OAuth2Client } from 'google-auth-library';
+import fetch from 'node-fetch';
+
+jest.mock('firebase-admin');
+jest.mock('google-auth-library');
+jest.mock('node-fetch', () => jest.fn());
+
+const adminAuthMock = {
+  getUserByEmail: jest.fn(),
+  createUser: jest.fn(),
+  verifyIdToken: jest.fn(),
+  getUser: jest.fn(),
+};
+
+(admin as any).auth = jest.fn(() => adminAuthMock);
+(admin as any).initializeApp = jest.fn();
+(admin as any).apps = [] as any;
+
+const verifyIdTokenMock = jest.fn();
+(OAuth2Client as any).mockImplementation(() => ({ verifyIdToken: verifyIdTokenMock }));
+
+const fetchMock = fetch as unknown as jest.Mock;
+
+describe('AuthService.signInWithGoogle', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns existing user', async () => {
+    verifyIdTokenMock.mockResolvedValue({ getPayload: () => ({ email: 'a@test.com' }) });
+    adminAuthMock.getUserByEmail.mockResolvedValue({ uid: 'uid1' });
+
+    const user = await AuthService.signInWithGoogle('token');
+    expect(user).toEqual({ uid: 'uid1' });
+    expect(adminAuthMock.getUserByEmail).toHaveBeenCalledWith('a@test.com');
+    expect(adminAuthMock.createUser).not.toHaveBeenCalled();
+  });
+
+  it('creates user if not found', async () => {
+    verifyIdTokenMock.mockResolvedValue({
+      getPayload: () => ({ email: 'b@test.com', sub: 'sub', name: 'Name', picture: 'pic', email_verified: true }),
+    });
+    const notFoundError = new Error('not found') as any;
+    notFoundError.code = 'auth/user-not-found';
+    adminAuthMock.getUserByEmail.mockRejectedValue(notFoundError);
+    adminAuthMock.createUser.mockResolvedValue({ uid: 'newuid' });
+
+    const user = await AuthService.signInWithGoogle('token');
+    expect(adminAuthMock.createUser).toHaveBeenCalledWith({
+      uid: 'sub',
+      email: 'b@test.com',
+      displayName: 'Name',
+      photoURL: 'pic',
+      emailVerified: true,
+    });
+    expect(user).toEqual({ uid: 'newuid' });
+  });
+});
+
+describe('AuthService.signInWithEmail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.FIREBASE_API_KEY = 'key';
+  });
+
+  it('signs in and returns user', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({ idToken: 'id' }),
+    });
+    adminAuthMock.verifyIdToken.mockResolvedValue({ uid: 'uid' });
+    adminAuthMock.getUser.mockResolvedValue({ uid: 'uid' });
+
+    const user = await AuthService.signInWithEmail('a@test.com', 'pass');
+    expect(fetchMock).toHaveBeenCalled();
+    expect(user).toEqual({ uid: 'uid' });
+  });
+
+  it('throws on auth failure', async () => {
+    fetchMock.mockResolvedValue({
+      ok: false,
+      json: async () => ({ error: { message: 'INVALID' } }),
+    });
+
+    await expect(AuthService.signInWithEmail('a@test.com', 'pass')).rejects.toThrow('INVALID');
+  });
+});


### PR DESCRIPTION
## Summary
- implement Google and email sign-in in auth service
- add Jest config and tests for AuthService
- configure package.json test script and dev deps

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535d73249483338a53f9579ea63f54