### PR TITLE
Implement role-based Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,17 +3,36 @@ rules_version = '2';
 service cloud.firestore {
   match /databases/{database}/documents {
 
-    // This rule allows anyone with your Firestore database reference to view, edit,
-    // and delete all data in your Firestore database. It is useful for getting
-    // started, but it is configured to expire after 30 days because it
-    // leaves your app open to attackers. At that time, all client
-    // requests to your Firestore database will be denied.
-    //
-    // Make sure to write security rules for your app before that time, or else
-    // all client requests to your Firestore database will be denied until you Update
-    // your rules
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function hasRole(r) {
+      return isSignedIn() && request.auth.token.role == r;
+    }
+
+    match /passes/{passId} {
+      allow read: if hasRole('dev') || hasRole('admin') || hasRole('teacher') || hasRole('support') ||
+        (hasRole('student') && request.auth.uid == resource.data.studentId);
+      allow write: if hasRole('dev') || hasRole('admin') || hasRole('teacher');
+    }
+
+    match /eventLogs/{eventId} {
+      allow read: if hasRole('dev') || hasRole('admin') || hasRole('teacher') || hasRole('support');
+      allow write: if hasRole('dev') || hasRole('admin');
+    }
+
+    match /users/{userId} {
+      allow read, write: if hasRole('dev') || hasRole('admin');
+    }
+
+    match /autonomyMatrix/{docId} {
+      allow read: if hasRole('dev') || hasRole('admin') || hasRole('teacher');
+      allow write: if hasRole('dev') || hasRole('admin');
+    }
+
     match /{document=**} {
-      allow read, write: if request.time < timestamp.date(2025, 7, 18);
+      allow read, write: if hasRole('dev');
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -23,7 +23,10 @@
   "devDependencies": {
     "@types/node": "^24.0.3",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "jest": "^29.7.0",
+    "@firebase/rules-unit-testing": "^4.0.1",
+    "firebase": "^11.9.1"
   },
   "dependencies": {
     "firebase-admin": "^13.4.0",

--- a/tests/firestore.rules.test.js
+++ b/tests/firestore.rules.test.js
@@ -1,0 +1,91 @@
+const fs = require('fs');
+const {initializeTestEnvironment, assertSucceeds, assertFails} = require('@firebase/rules-unit-testing');
+
+let testEnv;
+
+beforeAll(async () => {
+  testEnv = await initializeTestEnvironment({
+    projectId: 'dhp-test',
+    firestore: {rules: fs.readFileSync('firestore.rules', 'utf8')}
+  });
+});
+
+afterAll(async () => {
+  await testEnv.cleanup();
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+});
+
+function getAuthedDb(uid, role) {
+  return testEnv.authenticatedContext(uid, {role}).firestore();
+}
+
+function getAnonDb() {
+  return testEnv.unauthenticatedContext().firestore();
+}
+
+describe('firestore security rules', () => {
+  test('student can read own pass', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().collection('passes').doc('p1').set({studentId: 'stu1'});
+    });
+    const db = getAuthedDb('stu1', 'student');
+    await assertSucceeds(db.collection('passes').doc('p1').get());
+  });
+
+  test('student cannot read others pass', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().collection('passes').doc('p2').set({studentId: 'other'});
+    });
+    const db = getAuthedDb('stu1', 'student');
+    await assertFails(db.collection('passes').doc('p2').get());
+  });
+
+  test('student cannot write eventLogs', async () => {
+    const db = getAuthedDb('stu1', 'student');
+    await assertFails(db.collection('eventLogs').add({foo: 'bar'}));
+  });
+
+  test('teacher can read and write passes', async () => {
+    const db = getAuthedDb('t1', 'teacher');
+    await assertSucceeds(db.collection('passes').doc('p3').set({studentId: 's3'}));
+    await assertSucceeds(db.collection('passes').doc('p3').get());
+  });
+
+  test('teacher cannot write users', async () => {
+    const db = getAuthedDb('t1', 'teacher');
+    await assertFails(db.collection('users').doc('u1').set({}));
+  });
+
+  test('admin can read and write users', async () => {
+    const db = getAuthedDb('a1', 'admin');
+    await assertSucceeds(db.collection('users').doc('u2').set({role: 'student'}));
+    await assertSucceeds(db.collection('users').doc('u2').get());
+  });
+
+  test('admin can write autonomyMatrix', async () => {
+    const db = getAuthedDb('a1', 'admin');
+    await assertSucceeds(db.collection('autonomyMatrix').doc('loc1').set({type: 'Allow'}));
+  });
+
+  test('dev has full access', async () => {
+    const db = getAuthedDb('d1', 'dev');
+    await assertSucceeds(db.collection('any').doc('doc').set({}));
+    await assertSucceeds(db.collection('any').doc('doc').get());
+  });
+
+  test('support staff can read passes', async () => {
+    await testEnv.withSecurityRulesDisabled(async (ctx) => {
+      await ctx.firestore().collection('passes').doc('p4').set({studentId: 's4'});
+    });
+    const db = getAuthedDb('sup1', 'support');
+    await assertSucceeds(db.collection('passes').doc('p4').get());
+  });
+
+  test('anonymous denied', async () => {
+    const db = getAnonDb();
+    await assertFails(db.collection('passes').doc('p1').get());
+  });
+});


### PR DESCRIPTION
## Summary
- restrict Firestore access by role using custom claims
- add Jest security rule tests via the Firebase Emulator
- declare testing dependencies and script in `package.json`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68535d78bcfc8333b710e277db74a3e4