### PR TITLE
Add jest setup with example tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src', '<rootDir>/tests'],
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  testMatch: ['**/?(*.)+(test).ts?(x)']
+};

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest",
+    "test:watch": "jest --watch",
+    "test:coverage": "jest --coverage"
   },
   "repository": {
     "type": "git",
@@ -23,7 +25,10 @@
   "devDependencies": {
     "@types/node": "^24.0.3",
     "ts-node": "^10.9.2",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "@types/jest": "^29.5.11",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   },
   "dependencies": {
     "firebase-admin": "^13.4.0",

--- a/tests/authService.test.ts
+++ b/tests/authService.test.ts
@@ -1,0 +1,21 @@
+import { AuthService } from '../src/services/authService';
+import * as admin from 'firebase-admin';
+
+jest.mock('firebase-admin', () => {
+  const auth = { verifyIdToken: jest.fn() };
+  return {
+    auth: () => auth,
+    apps: [],
+    initializeApp: jest.fn(),
+  };
+});
+
+describe('AuthService.verifyIdToken', () => {
+  it('calls firebase-admin verifyIdToken and returns decoded token', async () => {
+    const decoded = { uid: '123' } as any;
+    (admin.auth() as any).verifyIdToken.mockResolvedValue(decoded);
+    const result = await AuthService.verifyIdToken('token123');
+    expect(admin.auth().verifyIdToken).toHaveBeenCalledWith('token123');
+    expect(result).toBe(decoded);
+  });
+});

--- a/tests/verifyAuth.test.ts
+++ b/tests/verifyAuth.test.ts
@@ -1,0 +1,33 @@
+import verifyAuth from '../src/middleware/verifyAuth';
+import { AuthService } from '../src/services/authService';
+
+jest.mock('../src/services/authService');
+
+describe('verifyAuth middleware', () => {
+  const res: any = {
+    status: jest.fn().mockReturnThis(),
+    json: jest.fn(),
+  };
+  const next = jest.fn();
+  let req: any;
+
+  beforeEach(() => {
+    req = { headers: {} };
+    jest.clearAllMocks();
+  });
+
+  it('responds with 401 when header missing', async () => {
+    await verifyAuth(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('calls AuthService and attaches user when token valid', async () => {
+    req.headers.authorization = 'Bearer token';
+    (AuthService.verifyIdToken as jest.Mock).mockResolvedValue({ uid: 'u1' });
+    await verifyAuth(req, res, next);
+    expect(AuthService.verifyIdToken).toHaveBeenCalledWith('token');
+    expect(req.user).toEqual({ uid: 'u1' });
+    expect(next).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- configure Jest for TypeScript
- add sample unit tests for AuthService and verifyAuth middleware
- expose test scripts in `package.json`

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68535d7d739083339d691de36b5fb130