### PR TITLE
Implement Firestore data models

### DIFF
--- a/docs/execution-ledger-v2.md
+++ b/docs/execution-ledger-v2.md
@@ -16,7 +16,7 @@
 |------|-----------|--------|-----------|-------------|----------|----------------|--------------------|-------|
 | 0 | Project Bootstrap Initialization | ✅ Completed | 2025-06-16T12:34Z | dev | Jane Doe | None | None | Project scaffold completed. |
 | 1 | Authentication & Authorization | 🚧 In Progress | 2024-06-16T00:00Z | dev | Jane Doe | None | None | Stubbed authService methods; implementation ongoing. |
-| 2 | Firestore Data Models & Schema Definitions | ⬜ Not Started | — | dev | Jane Doe | None | None | Pending implementation |
+| 2 | Firestore Data Models & Schema Definitions | ✅ Completed | 2024-06-17T00:00Z | dev | Jane Doe | None | None | Firestore models and schema scaffolds implemented |
 | 3 | Pass Lifecycle Engine | ⬜ Not Started | — | dev | Jane Doe | None | None | Pending implementation |
 | 4 | Emergency Freeze & Claim System | ⬜ Not Started | — | dev | Jane Doe | None | None | Pending implementation |
 | 5 | Notification Engine | ⬜ Not Started | — | dev | Jane Doe | None | None | Pending implementation |

--- a/src/models/firestoreModels.ts
+++ b/src/models/firestoreModels.ts
@@ -1,0 +1,78 @@
+import { Timestamp } from 'firebase-admin/firestore';
+
+/**
+ * Current schema version for all documents. Increment when schemas evolve.
+ */
+export const CURRENT_SCHEMA_VERSION = 1;
+
+/**
+ * Base fields included in every versioned document.
+ */
+export interface VersionedDocument {
+  /** Schema version of the document */
+  schemaVersion: number;
+}
+
+// Collection names in kebab-case
+export const USERS_COLLECTION = 'users';
+export const LOCATIONS_COLLECTION = 'locations';
+export const PASSES_COLLECTION = 'passes';
+export const EVENT_LOGS_COLLECTION = 'event-logs';
+export const GROUPS_COLLECTION = 'groups';
+export const AUTONOMY_MATRIX_COLLECTION = 'autonomy-matrix';
+export const RESTRICTIONS_COLLECTION = 'restrictions';
+
+export interface User extends VersionedDocument {
+  uid: string;
+  email: string;
+  role: 'student' | 'teacher' | 'admin' | 'support' | 'dev';
+  displayName?: string;
+  photoURL?: string;
+}
+
+export interface Location extends VersionedDocument {
+  id: string;
+  name: string;
+  type?: string;
+}
+
+export interface Pass extends VersionedDocument {
+  passId: string;
+  studentId: string;
+  originLocationId: string;
+  destinationLocationId: string;
+  openedAt: Timestamp;
+  closedAt?: Timestamp;
+  status: 'OPEN' | 'CLOSED';
+}
+
+export interface EventLog extends VersionedDocument {
+  eventId: string;
+  passId?: string;
+  actorId: string;
+  eventType: string;
+  timestamp: Timestamp;
+  metadata?: Record<string, unknown>;
+}
+
+export interface Group extends VersionedDocument {
+  id: string;
+  name: string;
+  type: 'Positive' | 'Negative';
+  members: string[];
+}
+
+export interface AutonomyMatrixEntry extends VersionedDocument {
+  id: string;
+  locationId: string;
+  groupId: string;
+  type: 'Allow' | 'Deny';
+}
+
+export interface Restriction extends VersionedDocument {
+  id: string;
+  studentId: string;
+  locationId?: string;
+  reason: string;
+  expiresAt?: Timestamp;
+}

--- a/tests/firestoreModels.test.ts
+++ b/tests/firestoreModels.test.ts
@@ -1,0 +1,38 @@
+import {
+  CURRENT_SCHEMA_VERSION,
+  USERS_COLLECTION,
+  LOCATIONS_COLLECTION,
+  PASSES_COLLECTION,
+  EVENT_LOGS_COLLECTION,
+  GROUPS_COLLECTION,
+  AUTONOMY_MATRIX_COLLECTION,
+  RESTRICTIONS_COLLECTION,
+  User,
+  VersionedDocument,
+} from '../src/models/firestoreModels';
+
+describe('firestoreModels', () => {
+  it('exposes collection name constants', () => {
+    expect(USERS_COLLECTION).toBe('users');
+    expect(LOCATIONS_COLLECTION).toBe('locations');
+    expect(PASSES_COLLECTION).toBe('passes');
+    expect(EVENT_LOGS_COLLECTION).toBe('event-logs');
+    expect(GROUPS_COLLECTION).toBe('groups');
+    expect(AUTONOMY_MATRIX_COLLECTION).toBe('autonomy-matrix');
+    expect(RESTRICTIONS_COLLECTION).toBe('restrictions');
+  });
+
+  it('includes a current schema version', () => {
+    expect(typeof CURRENT_SCHEMA_VERSION).toBe('number');
+  });
+
+  it('allows creating typed user objects', () => {
+    const user: User & VersionedDocument = {
+      uid: 'u1',
+      email: 'a@example.com',
+      role: 'student',
+      schemaVersion: CURRENT_SCHEMA_VERSION,
+    };
+    expect(user.uid).toBe('u1');
+  });
+});


### PR DESCRIPTION
## Summary
- add Firestore collection interfaces and collection constants
- track schema version in data models
- test firestore model exports
- update execution ledger for Task 2

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853f8a105748333a412ef325f62c27b