### PR TITLE
Implement domain restrictions and role middleware

### DIFF
--- a/docs/execution-ledger-v2.md
+++ b/docs/execution-ledger-v2.md
@@ -15,7 +15,7 @@
 | Step | Task Name | Status | Timestamp | Environment | Operator | Blocked Reason | AI Flags Triggered | Notes |
 |------|-----------|--------|-----------|-------------|----------|----------------|--------------------|-------|
 | 0 | Project Bootstrap Initialization | ✅ Completed | 2025-06-16T12:34Z | dev | Jane Doe | None | None | Project scaffold completed. |
-| 1 | Authentication & Authorization | 🚧 In Progress | 2024-06-16T00:00Z | dev | Jane Doe | None | None | Stubbed authService methods; implementation ongoing. |
+| 1 | Authentication & Authorization | ✅ Completed | 2024-06-18T00:00Z | dev | Jane Doe | None | None | Basic auth flows implemented and tested. |
 | 2 | Firestore Data Models & Schema Definitions | ✅ Completed | 2024-06-17T00:00Z | dev | Jane Doe | None | None | Firestore models and schema scaffolds implemented |
 | 3 | Pass Lifecycle Engine | ⬜ Not Started | — | dev | Jane Doe | None | None | Pending implementation |
 | 4 | Emergency Freeze & Claim System | ⬜ Not Started | — | dev | Jane Doe | None | None | Pending implementation |

--- a/src/middleware/authorizeRole.ts
+++ b/src/middleware/authorizeRole.ts
@@ -1,0 +1,17 @@
+import { Request, Response, NextFunction } from 'express';
+
+export default function authorizeRole(allowedRoles: string[]) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const user: any = (req as any).user;
+    if (!user) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    if (!allowedRoles.includes(user.role)) {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    if (req.params && req.params.uid && req.params.uid !== user.uid && user.role !== 'admin') {
+      return res.status(403).json({ error: 'Forbidden' });
+    }
+    next();
+  };
+}

--- a/tests/authService.test.ts
+++ b/tests/authService.test.ts
@@ -2,13 +2,21 @@ import { AuthService } from '../src/services/authService';
 import * as admin from 'firebase-admin';
 
 jest.mock('firebase-admin', () => {
-  const auth = { verifyIdToken: jest.fn() };
+  const auth = { verifyIdToken: jest.fn(), revokeRefreshTokens: jest.fn(), getUserByEmail: jest.fn(), createUser: jest.fn(), getUser: jest.fn() };
   return {
     auth: () => auth,
     apps: [],
     initializeApp: jest.fn(),
   };
 });
+
+jest.mock('google-auth-library', () => {
+  return {
+    OAuth2Client: jest.fn(),
+  };
+});
+
+jest.mock('node-fetch', () => jest.fn());
 
 describe('AuthService.verifyIdToken', () => {
   it('calls firebase-admin verifyIdToken and returns decoded token', async () => {
@@ -17,5 +25,39 @@ describe('AuthService.verifyIdToken', () => {
     const result = await AuthService.verifyIdToken('token123');
     expect(admin.auth().verifyIdToken).toHaveBeenCalledWith('token123');
     expect(result).toBe(decoded);
+  });
+});
+
+describe('AuthService.signInWithGoogle', () => {
+  const { OAuth2Client } = require('google-auth-library');
+
+  beforeEach(() => {
+    (OAuth2Client as jest.Mock).mockClear();
+  });
+
+  it('rejects sign-in for disallowed domain', async () => {
+    const instance = { verifyIdToken: jest.fn().mockResolvedValue({ getPayload: () => ({ email: 'user@bad.com' }) }) };
+    (OAuth2Client as jest.Mock).mockImplementation(() => instance);
+    await expect(AuthService.signInWithGoogle('idToken')).rejects.toThrow('Unauthorized domain');
+  });
+});
+
+describe('AuthService.signInWithEmail', () => {
+  const fetchMock = require('node-fetch');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('rejects sign-in for disallowed domain without calling fetch', async () => {
+    await expect(AuthService.signInWithEmail('user@bad.com', 'x')).rejects.toThrow('Unauthorized domain');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('AuthService.signOut', () => {
+  it('revokes refresh tokens', async () => {
+    await AuthService.signOut('uid1');
+    expect(admin.auth().revokeRefreshTokens).toHaveBeenCalledWith('uid1');
   });
 });

--- a/tests/authorizeRole.test.ts
+++ b/tests/authorizeRole.test.ts
@@ -1,0 +1,39 @@
+import authorizeRole from '../src/middleware/authorizeRole';
+
+const buildReq = (user?: any, params: any = {}) => ({ params, user });
+
+const res: any = {
+  status: jest.fn().mockReturnThis(),
+  json: jest.fn(),
+};
+
+const next = jest.fn();
+
+beforeEach(() => {
+  res.status.mockClear();
+  res.json.mockClear();
+  next.mockClear();
+});
+
+test('denies when role not allowed', () => {
+  const mw = authorizeRole(['admin']);
+  const req = buildReq({ uid: 'u1', role: 'student' });
+  mw(req as any, res, next);
+  expect(res.status).toHaveBeenCalledWith(403);
+  expect(next).not.toHaveBeenCalled();
+});
+
+test('denies when uid mismatch for non-admin', () => {
+  const mw = authorizeRole(['teacher']);
+  const req = buildReq({ uid: 'u1', role: 'teacher' }, { uid: 'u2' });
+  mw(req as any, res, next);
+  expect(res.status).toHaveBeenCalledWith(403);
+  expect(next).not.toHaveBeenCalled();
+});
+
+test('allows when role and uid valid', () => {
+  const mw = authorizeRole(['teacher']);
+  const req = buildReq({ uid: 'u1', role: 'teacher' }, { uid: 'u1' });
+  mw(req as any, res, next);
+  expect(next).toHaveBeenCalled();
+});


### PR DESCRIPTION
## Summary
- enforce allowed domains in `AuthService` sign-in methods
- revoke tokens on sign-out
- add middleware `authorizeRole`
- update tests for new auth behavior
- mark Task 1 complete in execution ledger

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853ff0cca64833393cd8b05a1bdc907