### PR TITLE
Implement emergency settings model

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Eagle Pass is a digital hall pass system designed for K-12 schools to track stud
 - Students close passes upon return to origin
 - Immutable event log for all state transitions
 - UI prevents invalid actions
+- System settings stored in `settings` collection (e.g., `emergencyFreeze` flag)
 - Dev dashboard for full system config and user management
 - Emergency freeze mode with claim functionality
 - Duration timers with notifications at 10min (student/teacher) and 20min (admin escalation)

--- a/docs/execution-ledger-v2.md
+++ b/docs/execution-ledger-v2.md
@@ -18,7 +18,7 @@
 | 1 | Authentication & Authorization | ✅ Completed | 2024-06-18T00:00Z | dev | Jane Doe | None | None | Basic auth flows implemented and tested. |
 | 2 | Firestore Data Models & Schema Definitions | ✅ Completed | 2024-06-17T00:00Z | dev | Jane Doe | None | None | Firestore models and schema scaffolds implemented |
 | 3 | Pass Lifecycle Engine | ✅ Completed | 2024-06-18T00:00Z | dev | Jane Doe | None | None | Implemented and tested pass lifecycle engine |
-| 4 | Emergency Freeze & Claim System | ⬜ Not Started | — | dev | Jane Doe | None | None | Pending implementation |
+| 4 | Emergency Freeze & Claim System | 🚧 In Progress | 2024-06-19T00:00Z | dev | Jane Doe | None | None | Data model and global toggle scaffolded |
 | 5 | Notification Engine | ⬜ Not Started | — | dev | Jane Doe | None | None | Pending implementation |
 | 6 | Data Ingestion Tooling (CSV Loader) | ⬜ Not Started | — | dev | Jane Doe | None | None | Pending implementation |
 | 7 | Teacher Assist Pass Closure | ⬜ Not Started | — | dev | Jane Doe | None | None | Pending implementation |

--- a/src/models/firestoreModels.ts
+++ b/src/models/firestoreModels.ts
@@ -21,6 +21,7 @@ export const EVENT_LOGS_COLLECTION = 'event-logs';
 export const GROUPS_COLLECTION = 'groups';
 export const AUTONOMY_MATRIX_COLLECTION = 'autonomy-matrix';
 export const RESTRICTIONS_COLLECTION = 'restrictions';
+export const SETTINGS_COLLECTION = 'settings';
 
 export interface User extends VersionedDocument {
   uid: string;
@@ -50,7 +51,12 @@ export interface EventLog extends VersionedDocument {
   eventId: string;
   passId?: string;
   actorId: string;
-  eventType: string;
+  eventType:
+    | 'CREATE_PASS'
+    | 'CLOSE_PASS'
+    | 'INVALID_TRANSITION'
+    | 'EMERGENCY_ACTIVATED'
+    | 'EMERGENCY_DEACTIVATED';
   timestamp: Timestamp;
   metadata?: Record<string, unknown>;
 }
@@ -75,4 +81,9 @@ export interface Restriction extends VersionedDocument {
   locationId?: string;
   reason: string;
   expiresAt?: Timestamp;
+}
+
+export interface SystemSettings extends VersionedDocument {
+  id: string;
+  emergencyFreeze: boolean;
 }

--- a/tests/firestoreModels.test.ts
+++ b/tests/firestoreModels.test.ts
@@ -7,6 +7,8 @@ import {
   GROUPS_COLLECTION,
   AUTONOMY_MATRIX_COLLECTION,
   RESTRICTIONS_COLLECTION,
+  SETTINGS_COLLECTION,
+  SystemSettings,
   User,
   VersionedDocument,
 } from '../src/models/firestoreModels';
@@ -20,6 +22,7 @@ describe('firestoreModels', () => {
     expect(GROUPS_COLLECTION).toBe('groups');
     expect(AUTONOMY_MATRIX_COLLECTION).toBe('autonomy-matrix');
     expect(RESTRICTIONS_COLLECTION).toBe('restrictions');
+    expect(SETTINGS_COLLECTION).toBe('settings');
   });
 
   it('includes a current schema version', () => {
@@ -34,5 +37,14 @@ describe('firestoreModels', () => {
       schemaVersion: CURRENT_SCHEMA_VERSION,
     };
     expect(user.uid).toBe('u1');
+  });
+
+  it('allows creating typed system settings objects', () => {
+    const settings: SystemSettings & VersionedDocument = {
+      id: 'global',
+      emergencyFreeze: false,
+      schemaVersion: CURRENT_SCHEMA_VERSION,
+    };
+    expect(settings.emergencyFreeze).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- add settings collection and SystemSettings interface
- include emergency event types in EventLog
- document settings collection in README
- note progress in execution ledger
- test model updates

## Testing
- `npm test` *(fails: The host and port of the firestore emulator must be specified)*

------
https://chatgpt.com/codex/tasks/task_e_68540251a7888333bd7cd96e9aeaa487