### PR TITLE
Add emergency service and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Eagle Pass is a digital hall pass system designed for K-12 schools to track stud
 - Students close passes upon return to origin
 - Immutable event log for all state transitions
 - UI prevents invalid actions
+- System settings stored in `settings` collection (e.g., `emergencyFreeze` flag)
 - Dev dashboard for full system config and user management
 - Emergency freeze mode with claim functionality
 - Duration timers with notifications at 10min (student/teacher) and 20min (admin escalation)

--- a/docs/execution-ledger-v2.md
+++ b/docs/execution-ledger-v2.md
@@ -18,7 +18,7 @@
 | 1 | Authentication & Authorization | ✅ Completed | 2024-06-18T00:00Z | dev | Jane Doe | None | None | Basic auth flows implemented and tested. |
 | 2 | Firestore Data Models & Schema Definitions | ✅ Completed | 2024-06-17T00:00Z | dev | Jane Doe | None | None | Firestore models and schema scaffolds implemented |
 | 3 | Pass Lifecycle Engine | ✅ Completed | 2024-06-18T00:00Z | dev | Jane Doe | None | None | Implemented and tested pass lifecycle engine |
-| 4 | Emergency Freeze & Claim System | ⬜ Not Started | — | dev | Jane Doe | None | None | Pending implementation |
+| 4 | Emergency Freeze & Claim System | 🚧 In Progress | 2024-06-19T00:00Z | dev | Jane Doe | None | None | Data model and global toggle scaffolded |
 | 5 | Notification Engine | ⬜ Not Started | — | dev | Jane Doe | None | None | Pending implementation |
 | 6 | Data Ingestion Tooling (CSV Loader) | ⬜ Not Started | — | dev | Jane Doe | None | None | Pending implementation |
 | 7 | Teacher Assist Pass Closure | ⬜ Not Started | — | dev | Jane Doe | None | None | Pending implementation |

--- a/src/models/firestoreModels.ts
+++ b/src/models/firestoreModels.ts
@@ -21,6 +21,7 @@ export const EVENT_LOGS_COLLECTION = 'event-logs';
 export const GROUPS_COLLECTION = 'groups';
 export const AUTONOMY_MATRIX_COLLECTION = 'autonomy-matrix';
 export const RESTRICTIONS_COLLECTION = 'restrictions';
+export const SETTINGS_COLLECTION = 'settings';
 
 export interface User extends VersionedDocument {
   uid: string;
@@ -50,7 +51,12 @@ export interface EventLog extends VersionedDocument {
   eventId: string;
   passId?: string;
   actorId: string;
-  eventType: string;
+  eventType:
+    | 'CREATE_PASS'
+    | 'CLOSE_PASS'
+    | 'INVALID_TRANSITION'
+    | 'EMERGENCY_ACTIVATED'
+    | 'EMERGENCY_DEACTIVATED';
   timestamp: Timestamp;
   metadata?: Record<string, unknown>;
 }
@@ -75,4 +81,9 @@ export interface Restriction extends VersionedDocument {
   locationId?: string;
   reason: string;
   expiresAt?: Timestamp;
+}
+
+export interface SystemSettings extends VersionedDocument {
+  id: string;
+  emergencyFreeze: boolean;
 }

--- a/src/services/emergencyService.ts
+++ b/src/services/emergencyService.ts
@@ -1,0 +1,56 @@
+import * as admin from 'firebase-admin';
+import {
+  SETTINGS_COLLECTION,
+  EVENT_LOGS_COLLECTION,
+  SystemSettings,
+  EventLog,
+  CURRENT_SCHEMA_VERSION,
+} from '../models/firestoreModels';
+import { PassService } from './passService';
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+export class EmergencyService {
+  private static db = admin.firestore();
+
+  private static settingsRef = EmergencyService.db
+    .collection(SETTINGS_COLLECTION)
+    .doc('global');
+
+  static async getEmergencyFreeze(): Promise<boolean> {
+    const snap = await this.settingsRef.get();
+    if (!snap.exists) {
+      return false;
+    }
+    const data = snap.data() as SystemSettings;
+    return data.emergencyFreeze;
+  }
+
+  static async setEmergencyFreeze(enabled: boolean, actorId: string): Promise<void> {
+    await this.settingsRef.set(
+      { id: 'global', emergencyFreeze: enabled, schemaVersion: CURRENT_SCHEMA_VERSION },
+      { merge: true },
+    );
+    const eventRef = this.db.collection(EVENT_LOGS_COLLECTION).doc();
+    const log: EventLog = {
+      eventId: eventRef.id,
+      actorId,
+      eventType: enabled ? 'EMERGENCY_ACTIVATED' : 'EMERGENCY_DEACTIVATED',
+      timestamp: admin.firestore.Timestamp.now(),
+      schemaVersion: CURRENT_SCHEMA_VERSION,
+    };
+    await eventRef.set(log);
+  }
+
+  static async emergencyClaimPass(passId: string, actorId: string): Promise<void> {
+    try {
+      await PassService.closePass(passId, actorId);
+    } catch {
+      throw new Error('INVALID_TRANSITION');
+    }
+  }
+}
+
+export default EmergencyService;

--- a/tests/emergencyService.test.ts
+++ b/tests/emergencyService.test.ts
@@ -1,0 +1,72 @@
+import { initializeTestEnvironment, RulesTestEnvironment } from '@firebase/rules-unit-testing';
+import * as admin from 'firebase-admin';
+import {
+  SETTINGS_COLLECTION,
+  EVENT_LOGS_COLLECTION,
+  PASSES_COLLECTION,
+} from '../src/models/firestoreModels';
+
+let testEnv: RulesTestEnvironment;
+let EmergencyService: typeof import('../src/services/emergencyService').EmergencyService;
+let PassService: typeof import('../src/services/passService').PassService;
+
+beforeAll(async () => {
+  process.env.FIRESTORE_EMULATOR_HOST = '127.0.0.1:8080';
+  testEnv = await initializeTestEnvironment({
+    projectId: 'dhp-test',
+    firestore: { host: '127.0.0.1', port: 8080 },
+  });
+  process.env.GCLOUD_PROJECT = testEnv.projectId;
+  ({ EmergencyService } = await import('../src/services/emergencyService'));
+  ({ PassService } = await import('../src/services/passService'));
+});
+
+afterAll(async () => {
+  await testEnv.cleanup();
+  delete process.env.FIRESTORE_EMULATOR_HOST;
+  delete process.env.GCLOUD_PROJECT;
+  if (admin.apps.length) {
+    await admin.app().delete();
+  }
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+});
+
+async function getDoc(collection: string, id: string) {
+  let snap: any;
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    snap = await ctx.firestore().collection(collection).doc(id).get();
+  });
+  return snap;
+}
+
+async function getCollection(collection: string) {
+  let snap: any;
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    snap = await ctx.firestore().collection(collection).get();
+  });
+  return snap;
+}
+
+test('setEmergencyFreeze stores flag and logs event', async () => {
+  await EmergencyService.setEmergencyFreeze(true, 'staff1');
+  const settingsSnap = await getDoc(SETTINGS_COLLECTION, 'global');
+  expect(settingsSnap.data()?.emergencyFreeze).toBe(true);
+  const logs = await getCollection(EVENT_LOGS_COLLECTION);
+  expect(logs.docs[0].data().eventType).toBe('EMERGENCY_ACTIVATED');
+});
+
+test('getEmergencyFreeze returns current value', async () => {
+  await EmergencyService.setEmergencyFreeze(true, 'staff1');
+  const flag = await EmergencyService.getEmergencyFreeze();
+  expect(flag).toBe(true);
+});
+
+test('emergencyClaimPass closes an open pass', async () => {
+  const passId = await PassService.createPass('stu1', 'a', 'b', 'actor1');
+  await EmergencyService.emergencyClaimPass(passId, 'staff1');
+  const passSnap = await getDoc(PASSES_COLLECTION, passId);
+  expect(passSnap.data()?.status).toBe('CLOSED');
+});

--- a/tests/firestoreModels.test.ts
+++ b/tests/firestoreModels.test.ts
@@ -7,6 +7,8 @@ import {
   GROUPS_COLLECTION,
   AUTONOMY_MATRIX_COLLECTION,
   RESTRICTIONS_COLLECTION,
+  SETTINGS_COLLECTION,
+  SystemSettings,
   User,
   VersionedDocument,
 } from '../src/models/firestoreModels';
@@ -20,6 +22,7 @@ describe('firestoreModels', () => {
     expect(GROUPS_COLLECTION).toBe('groups');
     expect(AUTONOMY_MATRIX_COLLECTION).toBe('autonomy-matrix');
     expect(RESTRICTIONS_COLLECTION).toBe('restrictions');
+    expect(SETTINGS_COLLECTION).toBe('settings');
   });
 
   it('includes a current schema version', () => {
@@ -34,5 +37,14 @@ describe('firestoreModels', () => {
       schemaVersion: CURRENT_SCHEMA_VERSION,
     };
     expect(user.uid).toBe('u1');
+  });
+
+  it('allows creating typed system settings objects', () => {
+    const settings: SystemSettings & VersionedDocument = {
+      id: 'global',
+      emergencyFreeze: false,
+      schemaVersion: CURRENT_SCHEMA_VERSION,
+    };
+    expect(settings.emergencyFreeze).toBe(false);
   });
 });

--- a/tests/passService.integration.test.ts
+++ b/tests/passService.integration.test.ts
@@ -6,8 +6,11 @@ let testEnv: RulesTestEnvironment;
 let PassService: typeof import('../src/services/passService').PassService;
 
 beforeAll(async () => {
-  testEnv = await initializeTestEnvironment({ projectId: 'dhp-test' });
   process.env.FIRESTORE_EMULATOR_HOST = '127.0.0.1:8080';
+  testEnv = await initializeTestEnvironment({
+    projectId: 'dhp-test',
+    firestore: { host: '127.0.0.1', port: 8080 },
+  });
   process.env.GCLOUD_PROJECT = testEnv.projectId;
   ({ PassService } = await import('../src/services/passService'));
 });


### PR DESCRIPTION
## Summary
- implement EmergencyService with freeze flag operations
- connect pass service integration tests to emulator host & port
- add tests covering emergency service behavior

## Testing
- `npm install`
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_68540251a7888333bd7cd96e9aeaa487