### PR TITLE
Add emergency freeze integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Eagle Pass is a digital hall pass system designed for K-12 schools to track stud
 - Students close passes upon return to origin
 - Immutable event log for all state transitions
 - UI prevents invalid actions
+- System settings stored in `settings` collection (e.g., `emergencyFreeze` flag)
 - Dev dashboard for full system config and user management
 - Emergency freeze mode with claim functionality
 - Duration timers with notifications at 10min (student/teacher) and 20min (admin escalation)

--- a/docs/execution-ledger-v2.md
+++ b/docs/execution-ledger-v2.md
@@ -18,7 +18,7 @@
 | 1 | Authentication & Authorization | ✅ Completed | 2024-06-18T00:00Z | dev | Jane Doe | None | None | Basic auth flows implemented and tested. |
 | 2 | Firestore Data Models & Schema Definitions | ✅ Completed | 2024-06-17T00:00Z | dev | Jane Doe | None | None | Firestore models and schema scaffolds implemented |
 | 3 | Pass Lifecycle Engine | ✅ Completed | 2024-06-18T00:00Z | dev | Jane Doe | None | None | Implemented and tested pass lifecycle engine |
-| 4 | Emergency Freeze & Claim System | ⬜ Not Started | — | dev | Jane Doe | None | None | Pending implementation |
+| 4 | Emergency Freeze & Claim System | 🚧 In Progress | 2024-06-19T00:00Z | dev | Jane Doe | None | None | Pass lifecycle integration with freeze flag |
 | 5 | Notification Engine | ⬜ Not Started | — | dev | Jane Doe | None | None | Pending implementation |
 | 6 | Data Ingestion Tooling (CSV Loader) | ⬜ Not Started | — | dev | Jane Doe | None | None | Pending implementation |
 | 7 | Teacher Assist Pass Closure | ⬜ Not Started | — | dev | Jane Doe | None | None | Pending implementation |

--- a/src/models/firestoreModels.ts
+++ b/src/models/firestoreModels.ts
@@ -21,6 +21,7 @@ export const EVENT_LOGS_COLLECTION = 'event-logs';
 export const GROUPS_COLLECTION = 'groups';
 export const AUTONOMY_MATRIX_COLLECTION = 'autonomy-matrix';
 export const RESTRICTIONS_COLLECTION = 'restrictions';
+export const SETTINGS_COLLECTION = 'settings';
 
 export interface User extends VersionedDocument {
   uid: string;
@@ -50,7 +51,13 @@ export interface EventLog extends VersionedDocument {
   eventId: string;
   passId?: string;
   actorId: string;
-  eventType: string;
+  eventType:
+    | 'CREATE_PASS'
+    | 'CLOSE_PASS'
+    | 'INVALID_TRANSITION'
+    | 'EMERGENCY_ACTIVATED'
+    | 'EMERGENCY_DEACTIVATED'
+    | 'EMERGENCY_CLAIM';
   timestamp: Timestamp;
   metadata?: Record<string, unknown>;
 }
@@ -75,4 +82,9 @@ export interface Restriction extends VersionedDocument {
   locationId?: string;
   reason: string;
   expiresAt?: Timestamp;
+}
+
+export interface SystemSettings extends VersionedDocument {
+  id: string;
+  emergencyFreeze: boolean;
 }

--- a/src/services/emergencyService.ts
+++ b/src/services/emergencyService.ts
@@ -1,0 +1,56 @@
+import * as admin from 'firebase-admin';
+import {
+  SETTINGS_COLLECTION,
+  EVENT_LOGS_COLLECTION,
+  SystemSettings,
+  EventLog,
+  CURRENT_SCHEMA_VERSION,
+} from '../models/firestoreModels';
+import { PassService } from './passService';
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
+
+export class EmergencyService {
+  private static db = admin.firestore();
+
+  private static settingsRef = EmergencyService.db
+    .collection(SETTINGS_COLLECTION)
+    .doc('global');
+
+  static async getEmergencyFreeze(): Promise<boolean> {
+    const snap = await this.settingsRef.get();
+    if (!snap.exists) {
+      return false;
+    }
+    const data = snap.data() as SystemSettings;
+    return data.emergencyFreeze;
+  }
+
+  static async setEmergencyFreeze(enabled: boolean, actorId: string): Promise<void> {
+    await this.settingsRef.set(
+      { id: 'global', emergencyFreeze: enabled, schemaVersion: CURRENT_SCHEMA_VERSION },
+      { merge: true },
+    );
+    const eventRef = this.db.collection(EVENT_LOGS_COLLECTION).doc();
+    const log: EventLog = {
+      eventId: eventRef.id,
+      actorId,
+      eventType: enabled ? 'EMERGENCY_ACTIVATED' : 'EMERGENCY_DEACTIVATED',
+      timestamp: admin.firestore.Timestamp.now(),
+      schemaVersion: CURRENT_SCHEMA_VERSION,
+    };
+    await eventRef.set(log);
+  }
+
+  static async emergencyClaimPass(passId: string, actorId: string): Promise<void> {
+    try {
+      await PassService.emergencyClaimPass(passId, actorId);
+    } catch {
+      throw new Error('INVALID_TRANSITION');
+    }
+  }
+}
+
+export default EmergencyService;

--- a/src/services/passService.ts
+++ b/src/services/passService.ts
@@ -3,6 +3,8 @@ import {
   CURRENT_SCHEMA_VERSION,
   PASSES_COLLECTION,
   EVENT_LOGS_COLLECTION,
+  SETTINGS_COLLECTION,
+  SystemSettings,
   Pass,
   EventLog,
 } from '../models/firestoreModels';
@@ -22,6 +24,26 @@ export class PassService {
   ): Promise<string> {
     const passRef = this.db.collection(PASSES_COLLECTION).doc();
     const eventRef = this.db.collection(EVENT_LOGS_COLLECTION).doc();
+
+    const settingsSnap = await this.db
+      .collection(SETTINGS_COLLECTION)
+      .doc('global')
+      .get();
+    if (
+      settingsSnap.exists &&
+      (settingsSnap.data() as SystemSettings).emergencyFreeze
+    ) {
+      const log: EventLog = {
+        eventId: eventRef.id,
+        actorId,
+        eventType: 'INVALID_TRANSITION',
+        timestamp: admin.firestore.Timestamp.now(),
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+        metadata: { reason: 'EMERGENCY_FREEZE' },
+      };
+      await eventRef.set(log);
+      throw new Error('INVALID_TRANSITION');
+    }
 
     const result = await this.db.runTransaction(async (tx) => {
       const openQuery = this.db
@@ -115,6 +137,60 @@ export class PassService {
         passId,
         actorId,
         eventType: 'CLOSE_PASS',
+        timestamp: admin.firestore.Timestamp.now(),
+        schemaVersion: CURRENT_SCHEMA_VERSION,
+      };
+      tx.set(eventRef, log);
+      return { success: true };
+    });
+
+    if (!result.success) {
+      throw new Error('INVALID_TRANSITION');
+    }
+  }
+
+  static async emergencyClaimPass(passId: string, actorId: string): Promise<void> {
+    const passRef = this.db.collection(PASSES_COLLECTION).doc(passId);
+    const eventRef = this.db.collection(EVENT_LOGS_COLLECTION).doc();
+
+    const result = await this.db.runTransaction(async (tx) => {
+      const snap = await tx.get(passRef);
+      if (!snap.exists) {
+        const invalid: EventLog = {
+          eventId: eventRef.id,
+          passId,
+          actorId,
+          eventType: 'INVALID_TRANSITION',
+          timestamp: admin.firestore.Timestamp.now(),
+          schemaVersion: CURRENT_SCHEMA_VERSION,
+          metadata: { reason: 'NOT_FOUND' },
+        };
+        tx.set(eventRef, invalid);
+        return { success: false };
+      }
+      const pass = snap.data() as Pass;
+      if (pass.status !== 'OPEN') {
+        const invalid: EventLog = {
+          eventId: eventRef.id,
+          passId,
+          actorId,
+          eventType: 'INVALID_TRANSITION',
+          timestamp: admin.firestore.Timestamp.now(),
+          schemaVersion: CURRENT_SCHEMA_VERSION,
+          metadata: { reason: 'ALREADY_CLOSED' },
+        };
+        tx.set(eventRef, invalid);
+        return { success: false };
+      }
+      tx.update(passRef, {
+        status: 'CLOSED',
+        closedAt: admin.firestore.Timestamp.now(),
+      });
+      const log: EventLog = {
+        eventId: eventRef.id,
+        passId,
+        actorId,
+        eventType: 'EMERGENCY_CLAIM',
         timestamp: admin.firestore.Timestamp.now(),
         schemaVersion: CURRENT_SCHEMA_VERSION,
       };

--- a/tests/emergencyService.test.ts
+++ b/tests/emergencyService.test.ts
@@ -1,0 +1,74 @@
+import { initializeTestEnvironment, RulesTestEnvironment } from '@firebase/rules-unit-testing';
+import * as admin from 'firebase-admin';
+import {
+  SETTINGS_COLLECTION,
+  EVENT_LOGS_COLLECTION,
+  PASSES_COLLECTION,
+} from '../src/models/firestoreModels';
+
+let testEnv: RulesTestEnvironment;
+let EmergencyService: typeof import('../src/services/emergencyService').EmergencyService;
+let PassService: typeof import('../src/services/passService').PassService;
+
+beforeAll(async () => {
+  process.env.FIRESTORE_EMULATOR_HOST = '127.0.0.1:8080';
+  testEnv = await initializeTestEnvironment({
+    projectId: 'dhp-test',
+    firestore: { host: '127.0.0.1', port: 8080 },
+  });
+  process.env.GCLOUD_PROJECT = testEnv.projectId;
+  ({ EmergencyService } = await import('../src/services/emergencyService'));
+  ({ PassService } = await import('../src/services/passService'));
+});
+
+afterAll(async () => {
+  await testEnv.cleanup();
+  delete process.env.FIRESTORE_EMULATOR_HOST;
+  delete process.env.GCLOUD_PROJECT;
+  if (admin.apps.length) {
+    await admin.app().delete();
+  }
+});
+
+beforeEach(async () => {
+  await testEnv.clearFirestore();
+});
+
+async function getDoc(collection: string, id: string) {
+  let snap: any;
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    snap = await ctx.firestore().collection(collection).doc(id).get();
+  });
+  return snap;
+}
+
+async function getCollection(collection: string) {
+  let snap: any;
+  await testEnv.withSecurityRulesDisabled(async (ctx) => {
+    snap = await ctx.firestore().collection(collection).get();
+  });
+  return snap;
+}
+
+test('setEmergencyFreeze stores flag and logs event', async () => {
+  await EmergencyService.setEmergencyFreeze(true, 'staff1');
+  const settingsSnap = await getDoc(SETTINGS_COLLECTION, 'global');
+  expect(settingsSnap.data()?.emergencyFreeze).toBe(true);
+  const logs = await getCollection(EVENT_LOGS_COLLECTION);
+  expect(logs.docs[0].data().eventType).toBe('EMERGENCY_ACTIVATED');
+});
+
+test('getEmergencyFreeze returns current value', async () => {
+  await EmergencyService.setEmergencyFreeze(true, 'staff1');
+  const flag = await EmergencyService.getEmergencyFreeze();
+  expect(flag).toBe(true);
+});
+
+test('emergencyClaimPass closes an open pass', async () => {
+  const passId = await PassService.createPass('stu1', 'a', 'b', 'actor1');
+  await EmergencyService.emergencyClaimPass(passId, 'staff1');
+  const passSnap = await getDoc(PASSES_COLLECTION, passId);
+  expect(passSnap.data()?.status).toBe('CLOSED');
+  const logs = await getCollection(EVENT_LOGS_COLLECTION);
+  expect(logs.docs[0].data().eventType).toBe('EMERGENCY_CLAIM');
+});

--- a/tests/firestoreModels.test.ts
+++ b/tests/firestoreModels.test.ts
@@ -7,9 +7,13 @@ import {
   GROUPS_COLLECTION,
   AUTONOMY_MATRIX_COLLECTION,
   RESTRICTIONS_COLLECTION,
+  SETTINGS_COLLECTION,
+  SystemSettings,
+  EventLog,
   User,
   VersionedDocument,
 } from '../src/models/firestoreModels';
+import * as admin from 'firebase-admin';
 
 describe('firestoreModels', () => {
   it('exposes collection name constants', () => {
@@ -20,6 +24,7 @@ describe('firestoreModels', () => {
     expect(GROUPS_COLLECTION).toBe('groups');
     expect(AUTONOMY_MATRIX_COLLECTION).toBe('autonomy-matrix');
     expect(RESTRICTIONS_COLLECTION).toBe('restrictions');
+    expect(SETTINGS_COLLECTION).toBe('settings');
   });
 
   it('includes a current schema version', () => {
@@ -34,5 +39,26 @@ describe('firestoreModels', () => {
       schemaVersion: CURRENT_SCHEMA_VERSION,
     };
     expect(user.uid).toBe('u1');
+  });
+
+  it('allows creating typed system settings objects', () => {
+    const settings: SystemSettings & VersionedDocument = {
+      id: 'global',
+      emergencyFreeze: false,
+      schemaVersion: CURRENT_SCHEMA_VERSION,
+    };
+    expect(settings.emergencyFreeze).toBe(false);
+  });
+
+  it('allows creating typed event log objects with new types', () => {
+    const log: EventLog & VersionedDocument = {
+      eventId: 'e1',
+      passId: 'p1',
+      actorId: 'a1',
+      eventType: 'EMERGENCY_CLAIM',
+      timestamp: admin.firestore.Timestamp.now(),
+      schemaVersion: CURRENT_SCHEMA_VERSION,
+    };
+    expect(log.eventType).toBe('EMERGENCY_CLAIM');
   });
 });


### PR DESCRIPTION
## Summary
- integrate freeze flag into pass creation flow
- log EMERGENCY_CLAIM events when claiming passes
- expose EMERGENCY_CLAIM type in models
- extend tests for emergency service and pass service
- update execution ledger

## Testing
- `npm install`
- `npm test` *(fails: connect ECONNREFUSED 127.0.0.1:8080)*

------
https://chatgpt.com/codex/tasks/task_e_68540251a7888333bd7cd96e9aeaa487