### PR TITLE
Add project scaffolding files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Example environment variables for local development
+# Copy this file to .env and provide real values
+FIREBASE_API_KEY=
+GCLOUD_PROJECT=
+FIREBASE_AUTH_DOMAIN=
+FIREBASE_DATABASE_URL=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ firebase-debug.log*
 # Environment variables
 .env
 .env.*
+!.env.example
 
 # OS
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ Eagle Pass is a digital hall pass system designed for K-12 schools to track stud
 2. Review the PRD and build queue for current scope
 3. Follow the operator SOP for all build and deployment actions
 4. Use the provided task queue to guide all development
+5. Copy `.env.example` to `.env` and add your Firebase config values
+6. Run `npm ci` then `npm test` to verify setup
 
 ---
 For questions or governance issues, refer to the escalation protocols in `docs/ai-governance/ai-governance.md` and `docs/ai-governance/ai-operator-sop.md`. 

--- a/src/security/README.md
+++ b/src/security/README.md
@@ -1,0 +1,3 @@
+# Security
+
+Security and access control logic.

--- a/src/utils/README.md
+++ b/src/utils/README.md
@@ -1,0 +1,3 @@
+# Utils
+
+Common utility functions.


### PR DESCRIPTION
## Summary
- ignore `.env.example` properly
- add placeholder readmes for utils and security folders
- provide `.env.example` template
- add GitHub Actions workflow running `npm ci` and `npm test`
- document setup steps in README

## Testing
- `npm test` *(fails: The host and port of the firestore emulator must be specified)*

------
https://chatgpt.com/codex/tasks/task_e_685465e045e88333ab72bad426e376d4